### PR TITLE
Terraform環境構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # tokyo-flutter-hackathon-2025-team-PlayGround
 東京Flutterハッカソン2025のteam-PlayGroundリポジトリ
+
+## 環境
+- dev環境（開発環境）
+- prod環境（本番環境）
+※stg環境は使用しない

--- a/docs/CORDING_GUIDE.md
+++ b/docs/CORDING_GUIDE.md
@@ -42,4 +42,9 @@
 - View は ConsumerStatefulWidget、ConsumerWidget、StatelessWidget、StatefulWidget のいずれかを用いること
 - ViewModel は Riverpod Generator を用いること
 
+## インフラ
+- 原則コンソールやCLIではなくTarraformでIaCを実現すること
+- 原則AWSを利用すること
+- 例外として一部インフラとしてGoogle Cloudを利用する
+
 ## Terraform

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -1,0 +1,95 @@
+# GET STARTED
+
+開発環境のセットアップガイド
+
+---
+
+## 1. Terraform環境のセットアップ
+
+### 1-1. 前提条件
+
+- AWS CLI がインストールされていること
+- Terraform がインストールされていること (v1.5.0以上)
+- `terraform-iam-user.json` が手元にあること
+
+### 1-2. Terraform実行用IAMユーザーの設定
+
+#### アクセスキーの確認
+
+`terraform-iam-user.json` の内容を確認：
+
+```json
+{
+    "AccessKey": {
+        "UserName": "terraform-iam-user",
+        "AccessKeyId": "AKIA...",
+        "SecretAccessKey": "...",
+        ...
+    }
+}
+```
+
+#### AWS CLIプロファイル設定
+
+```bash
+aws configure --profile terraform
+```
+
+入力内容：
+- **AWS Access Key ID**: `terraform-iam-user.json` の `AccessKeyId` をコピペ
+- **AWS Secret Access Key**: `terraform-iam-user.json` の `SecretAccessKey` をコピペ
+- **Default region name**: `ap-northeast-1`
+- **Default output format**: `json`
+
+#### 設定確認
+
+```bash
+aws sts get-caller-identity --profile terraform
+```
+
+期待される出力：
+```json
+{
+    "UserId": "AIDA...",
+    "Account": "851725222522",
+    "Arn": "arn:aws:iam::851725222522:user/terraform-iam-user"
+}
+```
+
+### 1-3. Terraform実行時の設定
+
+環境変数で指定：
+
+```bash
+export AWS_PROFILE=terraform
+```
+
+確認：
+```bash
+echo $AWS_PROFILE
+# 出力: terraform
+```
+
+### 1-4. Terraform実行
+
+dev環境の例：
+
+```bash
+cd infra/terraform/environments/dev
+export AWS_PROFILE=terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+---
+
+## 2. Flutter環境のセットアップ
+
+(TODO: 追加予定)
+
+---
+
+## 3. バックエンド環境のセットアップ
+
+(TODO: 追加予定)

--- a/infra/terraform/environments/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/environments/dev/providers.tf
+++ b/infra/terraform/environments/dev/providers.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+      Environment = "dev"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}

--- a/infra/terraform/environments/dev/remote-state.tf
+++ b/infra/terraform/environments/dev/remote-state.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "genkaimeshi-recipe-terraform-state"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,23 @@
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+  default     = "genkaimeshi-recipe"
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "gcp_project_id" {
+  description = "Google CloudプロジェクトID"
+  type        = string
+  default     = "genkaimeshi-recipe"
+}
+
+variable "gcp_region" {
+  description = "Google Cloudリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/infra/terraform/environments/dev/versions.tf
+++ b/infra/terraform/environments/dev/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/terraform/environments/prod/.terraform.lock.hcl
+++ b/infra/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/environments/prod/providers.tf
+++ b/infra/terraform/environments/prod/providers.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+      Environment = "prod"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}

--- a/infra/terraform/environments/prod/remote-state.tf
+++ b/infra/terraform/environments/prod/remote-state.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "genkaimeshi-recipe-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -1,0 +1,23 @@
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+  default     = "genkaimeshi-recipe"
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "gcp_project_id" {
+  description = "Google CloudプロジェクトID"
+  type        = string
+  default     = "genkaimeshi-recipe"
+}
+
+variable "gcp_region" {
+  description = "Google Cloudリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/infra/terraform/environments/prod/versions.tf
+++ b/infra/terraform/environments/prod/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/terraform/terraform-setup/.terraform.lock.hcl
+++ b/infra/terraform/terraform-setup/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/terraform-setup/dynamodb.tf
+++ b/infra/terraform/terraform-setup/dynamodb.tf
@@ -1,0 +1,15 @@
+resource "aws_dynamodb_table" "terraform_lock" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Terraform State Lock Table"
+    Description = "Terraformのstate lockに使用するテーブル"
+  }
+}

--- a/infra/terraform/terraform-setup/iam.tf
+++ b/infra/terraform/terraform-setup/iam.tf
@@ -1,0 +1,13 @@
+resource "aws_iam_user" "terraform_executor" {
+  name = var.terraform_iam_user_name
+
+  tags = {
+    Name        = "Terraform IAM User"
+    Description = "Terraform実行専用IAMユーザー"
+  }
+}
+
+resource "aws_iam_user_policy_attachment" "power_user" {
+  user       = aws_iam_user.terraform_executor.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}

--- a/infra/terraform/terraform-setup/outputs.tf
+++ b/infra/terraform/terraform-setup/outputs.tf
@@ -1,0 +1,46 @@
+output "state_bucket_name" {
+  description = "作成されたTerraform state用S3バケット名"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "state_bucket_arn" {
+  description = "作成されたTerraform state用S3バケットのARN"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "dynamodb_table_name" {
+  description = "作成されたTerraform lock用DynamoDBテーブル名"
+  value       = aws_dynamodb_table.terraform_lock.name
+}
+
+output "dynamodb_table_arn" {
+  description = "作成されたTerraform lock用DynamoDBテーブルのARN"
+  value       = aws_dynamodb_table.terraform_lock.arn
+}
+
+output "terraform_iam_user_name" {
+  description = "作成されたTerraform実行用IAMユーザー名"
+  value       = aws_iam_user.terraform_executor.name
+}
+
+output "terraform_iam_user_arn" {
+  description = "作成されたTerraform実行用IAMユーザーのARN"
+  value       = aws_iam_user.terraform_executor.arn
+}
+
+output "next_steps" {
+  description = "次のステップ"
+  value = <<-EOT
+
+  ✅ Bootstrap完了！次のステップ:
+
+  1. Terraform実行用IAMユーザーのアクセスキーを作成:
+     aws iam create-access-key --user-name ${aws_iam_user.terraform_executor.name}
+
+  2. 出力されたアクセスキーを新しいプロファイルとして設定:
+     aws configure --profile terraform
+
+  3. 以降のTerraform実行時は以下を指定:
+     export AWS_PROFILE=terraform
+  EOT
+}

--- a/infra/terraform/terraform-setup/providers.tf
+++ b/infra/terraform/terraform-setup/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+      Environment = "terraform-setup"
+    }
+  }
+}

--- a/infra/terraform/terraform-setup/s3.tf
+++ b/infra/terraform/terraform-setup/s3.tf
@@ -1,0 +1,35 @@
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.state_bucket_name
+
+  tags = {
+    Name        = "Terraform State Bucket"
+    Description = "Terraformのstateファイルを保存するバケット"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infra/terraform/terraform-setup/variables.tf
+++ b/infra/terraform/terraform-setup/variables.tf
@@ -1,0 +1,29 @@
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+  default     = "genkaimeshi-recipe"
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "state_bucket_name" {
+  description = "Terraform stateファイルを保存するS3バケット名"
+  type        = string
+  default     = "genkaimeshi-recipe-terraform-state"
+}
+
+variable "dynamodb_table_name" {
+  description = "Terraform state lockに使用するDynamoDBテーブル名"
+  type        = string
+  default     = "terraform-lock"
+}
+
+variable "terraform_iam_user_name" {
+  description = "Terraform実行専用IAMユーザー名"
+  type        = string
+  default     = "terraform-iam-user"
+}

--- a/infra/terraform/terraform-setup/versions.tf
+++ b/infra/terraform/terraform-setup/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
# Terraform環境構築

## 概要

プロジェクトのインフラ管理をIaCで実現するため、Terraformの環境構築を行いました。dev環境とprod環境の2つの環境を構築し、Terraformのstateファイルを安全に管理するためのバックエンド設定も含まれています。また、開発者がスムーズに環境構築できるよう、詳細なセットアップガイドも追加しました。

## 実装したこと

- **Terraformバックエンド管理用インフラの構築** (`terraform-setup`)
  - S3バケット（stateファイル保存用、バージョニング・暗号化・パブリックアクセスブロック有効化）
  - DynamoDBテーブル（state lock用）
  - IAMユーザーとポリシー設定

- **環境別Terraform設定の作成**
  - dev環境とprod環境のディレクトリ構成を作成
  - 各環境のproviders設定（AWS、Google Cloud）
  - S3バックエンド設定（環境ごとにstateファイルを分離）
  - 必要な変数定義とバージョン制約

- **モジュール構成の準備**
  - `infra/terraform/modules/aws/` と `infra/terraform/modules/gcp/` ディレクトリを作成（今後のモジュール化に備えて）

- **ドキュメントの整備**
  - `docs/GET_STARTED.md`: Terraform環境のセットアップ手順（IAMユーザー設定、AWS CLIプロファイル設定、Terraform実行手順）
  - `docs/CORDING_GUIDE.md`: インフラとTerraformに関するルールを追加
  - `docs/GIT_RULE.md`: デフォルトブランチがdevelopである旨を追記
  - `README.md`: 環境（dev/prod）に関する情報を追加

## 実装しなかったこと

- 実際のアプリケーションインフラリソース（EC2、RDS、Lambda等）の定義
  - 理由: まずは基盤となるTerraform環境とバックエンド管理の構築を優先したため
- stg環境の構築
  - 理由: プロジェクト方針としてdev環境とprod環境のみを使用することが決定されているため
- Flutter環境、バックエンド環境のセットアップガイド
  - 理由: 今回はTerraform環境のセットアップに焦点を当てたため（GET_STARTED.mdにTODOとして記載済み）

## UI

## その他

- Terraform実行時は環境変数 `AWS_PROFILE=terraform` の設定が必要です
- `terraform-iam-user.json` は機密情報のため、必ず安全に管理してください
- 今後のインフラリソース追加時は、環境別ディレクトリ配下またはモジュールとして実装してください
