### PR TITLE
BottomNavigationBarのUIをカスタムデザインに変更

### DIFF
--- a/app/lib/widgets/layout_scaffold.dart
+++ b/app/lib/widgets/layout_scaffold.dart
@@ -10,38 +10,75 @@ class LayoutScaffold extends StatelessWidget {
 
   /// 各タブのUIの情報をリスト化
   static const _tabs = [
-    (filled: Icons.home, outlined: Icons.home_outlined, label: 'レシピ'),
-    (filled: Icons.home, outlined: Icons.home_outlined, label: '投稿'),
-    (filled: Icons.home, outlined: Icons.home_outlined, label: 'AI生成'),
-    (filled: Icons.home, outlined: Icons.home_outlined, label: 'マイページ'),
-    (filled: Icons.home, outlined: Icons.home_outlined, label: 'ユーザー'),
+    (icon: Icons.settings, label: 'レシピ'),
+    (icon: Icons.list, label: '投稿'),
+    (icon: Icons.keyboard_double_arrow_up, label: 'AI生成'),
+    (icon: Icons.group, label: 'マイページ'),
+    (icon: Icons.person, label: 'ユーザー'),
   ];
-
-  /// 動的にアイコンを生成する。
-  ///
-  /// [currentIndex]が選択されているアイテムのindex。
-  ///
-  /// アイテムが選択されている場合はアイコンをfilledに、選択されていない場合はoutlinedにする。
-  List<BottomNavigationBarItem> _buildItems(int currentIndex) {
-    return _tabs.map((tab) {
-      final isSelected = currentIndex == _tabs.indexOf(tab);
-      return BottomNavigationBarItem(
-        icon: Icon(isSelected ? tab.filled : tab.outlined),
-        label: tab.label,
-      );
-    }).toList();
-  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: navigationShell,
-      bottomNavigationBar: BottomNavigationBar(
-        type: BottomNavigationBarType.fixed,
-        backgroundColor: Colors.white,
-        currentIndex: navigationShell.currentIndex,
-        onTap: navigationShell.goBranch,
-        items: _buildItems(navigationShell.currentIndex),
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+          color: Color(0xFF487F38),
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(30),
+            topRight: Radius.circular(30),
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: SafeArea(
+          top: false,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _buildNavItem(0, _tabs[0].icon),
+              _buildNavItem(1, _tabs[1].icon),
+              _buildCenterButton(),
+              _buildNavItem(3, _tabs[3].icon),
+              _buildNavItem(4, _tabs[4].icon),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNavItem(int index, IconData icon) {
+    return IconButton(
+      icon: Icon(icon, color: Colors.white, size: 32),
+      onPressed: () => navigationShell.goBranch(index),
+    );
+  }
+
+  Widget _buildCenterButton() {
+    return GestureDetector(
+      onTap: () => navigationShell.goBranch(2),
+      child: Container(
+        width: 80,
+        height: 80,
+        decoration: const BoxDecoration(
+          color: Color(0xFFE57373),
+          shape: BoxShape.circle,
+        ),
+        child: const Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.keyboard_double_arrow_up, color: Colors.white, size: 32),
+            SizedBox(height: 4),
+            Text(
+              '生成する',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
標準のBottomNavigationBarから緑色背景の角丸デザインに変更し、中央に赤い円形の「生成する」ボタンを配置 左右に設定、リスト、グループ、ユーザーアイコンを白色で表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# （ここにタイトル）

<!-- 実際の実装内容に置き換えてください -->

## 概要

<!-- この実装の概要や目的を記載してください -->

## 実装したこと

<!-- どのような変更を加えたのか具体的に記載してください -->

## 実装しなかったこと

<!-- 実装を見送った項目とその理由を記載してください -->

## UI

<!-- UIに変更があれば記載してください（モバイル端末のスクショは<img src="" width="320">を使用） -->

## その他

<!-- その他補足があれば記載してください -->
